### PR TITLE
Do not push image to docker hub

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -30,14 +30,6 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Login Github Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:


### PR DESCRIPTION
Image is now pushed to ghcr.io, so we can skip pushing it to docker.io.
Signed-off-by: Anil Vishnoi <avishnoi@redhat.com>