### PR TITLE
Legacy BPF maps coded into BTF defined maps

### DIFF
--- a/bpf/include/helpers/common.h
+++ b/bpf/include/helpers/common.h
@@ -18,27 +18,6 @@ limitations under the License.
 // code.
 
 #pragma once
-
-typedef unsigned char __u8;
-typedef short int __s16;
-typedef short unsigned int __u16;
-typedef int __s32;
-typedef unsigned int __u32;
-typedef long long int __s64;
-typedef long long unsigned int __u64;
-typedef __u8 u8;
-typedef __s16 s16;
-typedef __u16 u16;
-typedef __s32 s32;
-typedef __u32 u32;
-typedef __s64 s64;
-typedef __u64 u64;
-typedef __u16 __le16;
-typedef __u16 __be16;
-typedef __u32 __be32;
-typedef __u64 __be64;
-typedef __u32 __wsum;
-
 #define BPF_F_INDEX_MASK 0xffffffffULL
 #define BPF_F_CURRENT_CPU BPF_F_INDEX_MASK
 

--- a/bpf/include/helpers/helpers.h
+++ b/bpf/include/helpers/helpers.h
@@ -58,16 +58,6 @@ struct socket_key {
   __u16 dst_port;
 };
 
-struct bpf_map {
-  __u32 id;
-  __u32 type;
-  __u32 key_size;
-  __u32 value_size;
-  __u32 max_elem;
-  __u32 flags;
-  __u32 pinning;
-};
-
 static __u64 BPF_FUNC(get_current_pid_tgid);
 static __u64 BPF_FUNC(get_current_uid_gid);
 static void BPF_FUNC(trace_printk, const char *fmt, int fmt_size, ...);

--- a/bpf/include/helpers/maps.h
+++ b/bpf/include/helpers/maps.h
@@ -17,18 +17,11 @@
 
 #include "common.h"
 
-/*struct bpf_map __section("maps") sockops_redir_map = {
-    .type = BPF_MAP_TYPE_SOCKHASH,
-    .key_size = sizeof(struct socket_key),
-    .value_size = sizeof(__u32),
-    .max_elem = 65535,
-};*/
-
 #define MAX_ELEMENT 65535
 
 struct btf_map {
   __uint(type, BPF_MAP_TYPE_SOCKHASH);
   __uint(max_elem, MAX_ELEMENT);
   __type(key, struct socket_key);
-  __type(value, u32);
+  __type(value, __u32);
 } sockops_redir_map SEC(".maps");


### PR DESCRIPTION
As proposed in issue #50, sockops_redir_map coded as BTF-defined map. 

Testing approach:
patu.yml applied and tested before change - all ebpf programs loaded successfully, map created with sockhash type; no elements
patu.yml applied and tested post change - results replicated as before. 

Resolves: #50
