### PR TITLE
Add default gateway route support

### DIFF
--- a/cmd/patu/cni/patu-cni.go
+++ b/cmd/patu/cni/patu-cni.go
@@ -20,7 +20,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -32,547 +34,750 @@ import (
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/utils"
 	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
 	"github.com/containernetworking/plugins/pkg/utils/sysctl"
 )
-
-const defaultBrName = "cni0"
-
-type NetConf struct {
-	types.NetConf
-	BrName    string `json:"defaultBridge"`
-	MTU       int    `json:"mtu"`
-	EnableDad bool   `json:"enabledad,omitempty"`
-	mac       string
+ 
+ const defaultBrName = "patux"
+ 
+ type NetConf struct {
+	 types.NetConf
+	BrName       string `json:"bridge"`
+	IsGW         bool   `json:"isGateway"`
+	ForceAddress bool   `json:"forceAddress"`
+	MTU          int    `json:"mtu"`
+	IPMasq       bool   `json:"ipMasq"`
+	HairpinMode  bool   `json:"hairpinMode"`
+}
+ 
+type gwInfo struct {
+	gws               []net.IPNet
+	family            int
 }
 
-// MacEnvArgs represents CNI_ARGS
-type MacEnvArgs struct {
-	types.CommonArgs
-	MAC types.UnmarshallableString `json:"mac,omitempty"`
-}
+ func loadNetConf(bytes []byte, envArgs string) (*NetConf, string, error) {
+	 n := &NetConf{
+		 BrName: defaultBrName,
+	 }
+	 if err := json.Unmarshal(bytes, n); err != nil {
+		 return nil, "", fmt.Errorf("failed to load netconf: %v", err)
+	 }
+	 return n, n.CNIVersion, nil
+ }
+ 
+// calcGateways processes the results from the IPAM plugin and does the
+// following for each IP family:
+//    - Calculates and compiles a list of gateway addresses
+//    - Adds a default route if needed
+func calcGateways(result *current.Result, n *NetConf) (*gwInfo, *gwInfo, error) {
 
-func loadNetConf(bytes []byte, envArgs string) (*NetConf, string, error) {
-	n := &NetConf{
-		BrName: defaultBrName,
-	}
-	if err := json.Unmarshal(bytes, n); err != nil {
-		return nil, "", fmt.Errorf("failed to load netconf: %v", err)
-	}
+	gwsV4 := &gwInfo{}
+	gwsV6 := &gwInfo{}
 
-	if envArgs != "" {
-		e := MacEnvArgs{}
-		if err := types.LoadArgs(envArgs, &e); err != nil {
-			return nil, "", err
+	for _, ipc := range result.IPs {
+
+		// Determine if this config is IPv4 or IPv6
+		var gws *gwInfo
+		defaultNet := &net.IPNet{}
+		switch {
+		case ipc.Address.IP.To4() != nil:
+			gws = gwsV4
+			gws.family = netlink.FAMILY_V4
+			defaultNet.IP = net.IPv4zero
+		case len(ipc.Address.IP) == net.IPv6len:
+			gws = gwsV6
+			gws.family = netlink.FAMILY_V6
+			defaultNet.IP = net.IPv6zero
+		default:
+			return nil, nil, fmt.Errorf("Unknown IP object: %v", ipc)
+		}
+		defaultNet.Mask = net.IPMask(defaultNet.IP)
+
+		// All IPs currently refer to the container interface
+		ipc.Interface = current.Int(2)
+
+		// If not provided, calculate the gateway address corresponding
+		// to the selected IP address
+		if ipc.Gateway == nil && n.IsGW {
+			ipc.Gateway = calcGatewayIP(&ipc.Address)
 		}
 
-		if e.MAC != "" {
-			n.mac = string(e.MAC)
+		// Append this gateway address to the list of gateways
+		if n.IsGW {
+			gw := net.IPNet{
+				IP:   ipc.Gateway,
+				Mask: ipc.Address.Mask,
+			}
+			gws.gws = append(gws.gws, gw)
 		}
 	}
-	return n, n.CNIVersion, nil
+	return gwsV4, gwsV6, nil
 }
 
-func bridgeByName(name string) (*netlink.Bridge, error) {
-	l, err := netlink.LinkByName(name)
-	if err != nil {
-		return nil, fmt.Errorf("could not lookup %q: %v", name, err)
-	}
-	br, ok := l.(*netlink.Bridge)
-	if !ok {
-		return nil, fmt.Errorf("%q already exists but is not a bridge", name)
-	}
-	return br, nil
-}
-
-func setupVeth(netns ns.NetNS, br *netlink.Bridge, ifName string, mtu int, mac string) (*current.Interface, *current.Interface, error) {
-	contIface := &current.Interface{}
-	hostIface := &current.Interface{}
-
-	err := netns.Do(func(hostNS ns.NetNS) error {
-		// create the veth pair in the container and move host end into host netns
-		hostVeth, containerVeth, err := ip.SetupVeth(ifName, mtu, mac, hostNS)
-		if err != nil {
-			return err
-		}
-		contIface.Name = containerVeth.Name
-		contIface.Mac = containerVeth.HardwareAddr.String()
-		contIface.Sandbox = netns.Path()
-		hostIface.Name = hostVeth.Name
-		return nil
-	})
-	if err != nil {
-		return nil, nil, err
+func ensureAddr(br netlink.Link, family int, ipn *net.IPNet, forceAddress bool) error {
+	addrs, err := netlink.AddrList(br, family)
+	if err != nil && err != syscall.ENOENT {
+		return fmt.Errorf("could not get list of IP addresses: %v", err)
 	}
 
-	// need to lookup hostVeth again as its index has changed during ns move
-	hostVeth, err := netlink.LinkByName(hostIface.Name)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to lookup %q: %v", hostIface.Name, err)
-	}
-	hostIface.Mac = hostVeth.Attrs().HardwareAddr.String()
+	ipnStr := ipn.String()
+	for _, a := range addrs {
 
-	// connect host veth end to the bridge
-	if err := netlink.LinkSetMaster(hostVeth, br); err != nil {
-		return nil, nil, fmt.Errorf("failed to connect %q to bridge %v: %v", hostVeth.Attrs().Name, br.Attrs().Name, err)
-	}
-
-	return hostIface, contIface, nil
-}
-
-func getDefaultBridge(n *NetConf) (*netlink.Bridge, *current.Interface, error) {
-
-	br, err := bridgeByName(n.BrName)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// we want to own the routes for this interface
-	_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", n.BrName), "0")
-
-	return br, &current.Interface{
-		Name: br.Attrs().Name,
-		Mac:  br.Attrs().HardwareAddr.String(),
-	}, nil
-}
-
-func cmdAdd(args *skel.CmdArgs) error {
-	var success bool = false
-
-	n, cniVersion, err := loadNetConf(args.StdinData, args.Args)
-	if err != nil {
-		return err
-	}
-
-	isLayer3 := n.IPAM.Type != ""
-
-	br, brInterface, err := getDefaultBridge(n)
-	if err != nil {
-		return err
-	}
-
-	netns, err := ns.GetNS(args.Netns)
-	if err != nil {
-		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
-	}
-	defer netns.Close()
-
-	hostInterface, containerInterface, err := setupVeth(netns, br, args.IfName, n.MTU, n.mac)
-	if err != nil {
-		return err
-	}
-
-	// Assume L2 interface only
-	result := &current.Result{
-		CNIVersion: current.ImplementedSpecVersion,
-		Interfaces: []*current.Interface{
-			brInterface,
-			hostInterface,
-			containerInterface,
-		},
-	}
-
-	if isLayer3 {
-		// run the IPAM plugin and get back the config to apply
-		r, err := ipam.ExecAdd(n.IPAM.Type, args.StdinData)
-		if err != nil {
-			return err
+		// string comp is actually easiest for doing IPNet comps
+		if a.IPNet.String() == ipnStr {
+			return nil
 		}
 
-		// release IP in case of failure
-		defer func() {
-			if !success {
-				if err := ipam.ExecDel(n.IPAM.Type, args.StdinData); err != nil {
-					fmt.Fprintf(os.Stderr, "%v", err)
+		// Multiple IPv6 addresses are allowed on the bridge if the
+		// corresponding subnets do not overlap. For IPv4 or for
+		// overlapping IPv6 subnets, reconfigure the IP address if
+		// forceAddress is true, otherwise throw an error.
+		if family == netlink.FAMILY_V4 || a.IPNet.Contains(ipn.IP) || ipn.Contains(a.IPNet.IP) {
+			if forceAddress {
+				if err = deleteAddr(br, a.IPNet); err != nil {
+					return err
 				}
-			}
-		}()
-
-		// Convert whatever the IPAM result was into the current Result type
-		ipamResult, err := current.NewResultFromResult(r)
-		if err != nil {
-			return err
-		}
-
-		result.IPs = ipamResult.IPs
-		result.Routes = ipamResult.Routes
-		result.DNS = ipamResult.DNS
-
-		if len(result.IPs) == 0 {
-			return errors.New("IPAM plugin returned missing IP config")
-		}
-
-		// Configure the container hardware address and IP address(es)
-		if err := netns.Do(func(_ ns.NetNS) error {
-			if n.EnableDad {
-				_, _ = sysctl.Sysctl(fmt.Sprintf("/net/ipv6/conf/%s/enhanced_dad", args.IfName), "1")
-				_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv6/conf/%s/accept_dad", args.IfName), "1")
 			} else {
-				_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv6/conf/%s/accept_dad", args.IfName), "0")
-			}
-			_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/arp_notify", args.IfName), "1")
-
-			// Add the IP to the interface
-			if err := ipam.ConfigureIface(args.IfName, result); err != nil {
-				return err
-			}
-			return nil
-		}); err != nil {
-			return err
-		}
-
-		// check bridge port state
-		retries := []int{0, 50, 500, 1000, 1000}
-		for idx, sleep := range retries {
-			time.Sleep(time.Duration(sleep) * time.Millisecond)
-
-			hostVeth, err := netlink.LinkByName(hostInterface.Name)
-			if err != nil {
-				return err
-			}
-			if hostVeth.Attrs().OperState == netlink.OperUp {
-				break
-			}
-
-			if idx == len(retries)-1 {
-				return fmt.Errorf("bridge port in error state: %s", hostVeth.Attrs().OperState)
-			}
-		}
-	} else {
-		if err := netns.Do(func(_ ns.NetNS) error {
-			link, err := netlink.LinkByName(args.IfName)
-			if err != nil {
-				return fmt.Errorf("failed to retrieve link: %v", err)
-			}
-			// If layer 2 we still need to set the container veth to up
-			if err = netlink.LinkSetUp(link); err != nil {
-				return fmt.Errorf("failed to set %q up: %v", args.IfName, err)
-			}
-			return nil
-		}); err != nil {
-			return err
-		}
-	}
-
-	// Refetch the bridge since its MAC address may change when the first
-	// veth is added or after its IP address is set
-	br, err = bridgeByName(n.BrName)
-	if err != nil {
-		return err
-	}
-	brInterface.Mac = br.Attrs().HardwareAddr.String()
-
-	success = true
-
-	return types.PrintResult(result, cniVersion)
-}
-
-func cmdDel(args *skel.CmdArgs) error {
-	n, _, err := loadNetConf(args.StdinData, args.Args)
-	if err != nil {
-		return err
-	}
-
-	isLayer3 := n.IPAM.Type != ""
-
-	ipamDel := func() error {
-		if isLayer3 {
-			if err := ipam.ExecDel(n.IPAM.Type, args.StdinData); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	if args.Netns == "" {
-		return ipamDel()
-	}
-
-	// There is a netns so try to clean up. Delete can be called multiple times
-	// so don't return an error if the device is already removed.
-	// If the device isn't there then don't try to clean up IP masq either.
-	err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
-		var err error
-		_, err = ip.DelLinkByNameAddr(args.IfName)
-		if err != nil && err == ip.ErrLinkNotFound {
-			return nil
-		}
-		return err
-	})
-
-	if err != nil {
-		//  if NetNs is passed down by the Cloud Orchestration Engine, or if it called multiple times
-		// so don't return an error if the device is already removed.
-		// https://github.com/kubernetes/kubernetes/issues/43014#issuecomment-287164444
-		_, ok := err.(ns.NSPathNotExistErr)
-		if ok {
-			return ipamDel()
-		}
-		return err
-	}
-
-	// call ipam.ExecDel after clean up device in netns
-	if err := ipamDel(); err != nil {
-		return err
-	}
-
-	return err
-}
-
-type cniBridgeIf struct {
-	Name        string
-	ifIndex     int
-	peerIndex   int
-	masterIndex int
-	found       bool
-}
-
-func validateInterface(intf current.Interface, expectInSb bool) (cniBridgeIf, netlink.Link, error) {
-
-	ifFound := cniBridgeIf{found: false}
-	if intf.Name == "" {
-		return ifFound, nil, fmt.Errorf("Interface name missing ")
-	}
-
-	link, err := netlink.LinkByName(intf.Name)
-	if err != nil {
-		return ifFound, nil, fmt.Errorf("Interface name %s not found", intf.Name)
-	}
-
-	if expectInSb {
-		if intf.Sandbox == "" {
-			return ifFound, nil, fmt.Errorf("Interface %s is expected to be in a sandbox", intf.Name)
-		}
-	} else {
-		if intf.Sandbox != "" {
-			return ifFound, nil, fmt.Errorf("Interface %s should not be in sandbox", intf.Name)
-		}
-	}
-
-	return ifFound, link, err
-}
-
-func validateCniBrInterface(intf current.Interface, n *NetConf) (cniBridgeIf, error) {
-
-	brFound, link, err := validateInterface(intf, false)
-	if err != nil {
-		return brFound, err
-	}
-
-	_, isBridge := link.(*netlink.Bridge)
-	if !isBridge {
-		return brFound, fmt.Errorf("Interface %s does not have link type of bridge", intf.Name)
-	}
-
-	if intf.Mac != "" {
-		if intf.Mac != link.Attrs().HardwareAddr.String() {
-			return brFound, fmt.Errorf("Bridge interface %s Mac doesn't match: %s", intf.Name, intf.Mac)
-		}
-	}
-
-	brFound.found = true
-	brFound.Name = link.Attrs().Name
-	brFound.ifIndex = link.Attrs().Index
-	brFound.masterIndex = link.Attrs().MasterIndex
-
-	return brFound, nil
-}
-
-func validateCniVethInterface(intf *current.Interface, brIf cniBridgeIf, contIf cniBridgeIf) (cniBridgeIf, error) {
-
-	vethFound, link, err := validateInterface(*intf, false)
-	if err != nil {
-		return vethFound, err
-	}
-
-	_, isVeth := link.(*netlink.Veth)
-	if !isVeth {
-		// just skip it, it's not what CNI created
-		return vethFound, nil
-	}
-
-	_, vethFound.peerIndex, err = ip.GetVethPeerIfindex(link.Attrs().Name)
-	if err != nil {
-		return vethFound, fmt.Errorf("Unable to obtain veth peer index for veth %s", link.Attrs().Name)
-	}
-	vethFound.ifIndex = link.Attrs().Index
-	vethFound.masterIndex = link.Attrs().MasterIndex
-
-	if vethFound.ifIndex != contIf.peerIndex {
-		return vethFound, nil
-	}
-
-	if contIf.ifIndex != vethFound.peerIndex {
-		return vethFound, nil
-	}
-
-	if vethFound.masterIndex != brIf.ifIndex {
-		return vethFound, nil
-	}
-
-	if intf.Mac != "" {
-		if intf.Mac != link.Attrs().HardwareAddr.String() {
-			return vethFound, fmt.Errorf("Interface %s Mac doesn't match: %s not found", intf.Name, intf.Mac)
-		}
-	}
-
-	vethFound.found = true
-	vethFound.Name = link.Attrs().Name
-
-	return vethFound, nil
-}
-
-func validateCniContainerInterface(intf current.Interface) (cniBridgeIf, error) {
-
-	vethFound, link, err := validateInterface(intf, true)
-	if err != nil {
-		return vethFound, err
-	}
-
-	_, isVeth := link.(*netlink.Veth)
-	if !isVeth {
-		return vethFound, fmt.Errorf("Error: Container interface %s not of type veth", link.Attrs().Name)
-	}
-	_, vethFound.peerIndex, err = ip.GetVethPeerIfindex(link.Attrs().Name)
-	if err != nil {
-		return vethFound, fmt.Errorf("Unable to obtain veth peer index for veth %s", link.Attrs().Name)
-	}
-	vethFound.ifIndex = link.Attrs().Index
-
-	if intf.Mac != "" {
-		if intf.Mac != link.Attrs().HardwareAddr.String() {
-			return vethFound, fmt.Errorf("Interface %s Mac %s doesn't match container Mac: %s", intf.Name, intf.Mac, link.Attrs().HardwareAddr)
-		}
-	}
-
-	vethFound.found = true
-	vethFound.Name = link.Attrs().Name
-
-	return vethFound, nil
-}
-
-func cmdCheck(args *skel.CmdArgs) error {
-	n, _, err := loadNetConf(args.StdinData, args.Args)
-	if err != nil {
-		return err
-	}
-	netns, err := ns.GetNS(args.Netns)
-	if err != nil {
-		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
-	}
-	defer netns.Close()
-
-	// run the IPAM plugin and get back the config to apply
-	err = ipam.ExecCheck(n.IPAM.Type, args.StdinData)
-	if err != nil {
-		return err
-	}
-
-	// Parse previous result.
-	if n.NetConf.RawPrevResult == nil {
-		return fmt.Errorf("Required prevResult missing")
-	}
-
-	if err := version.ParsePrevResult(&n.NetConf); err != nil {
-		return err
-	}
-
-	result, err := current.NewResultFromResult(n.PrevResult)
-	if err != nil {
-		return err
-	}
-
-	var errLink error
-	var contCNI, vethCNI cniBridgeIf
-	var brMap, contMap current.Interface
-
-	// Find interfaces for names we know, CNI Bridge and container
-	for _, intf := range result.Interfaces {
-		if n.BrName == intf.Name {
-			brMap = *intf
-			continue
-		} else if args.IfName == intf.Name {
-			if args.Netns == intf.Sandbox {
-				contMap = *intf
-				continue
+				return fmt.Errorf("%q already has an IP address different from %v", br.Attrs().Name, ipnStr)
 			}
 		}
 	}
 
-	brCNI, err := validateCniBrInterface(brMap, n)
-	if err != nil {
-		return err
+	addr := &netlink.Addr{IPNet: ipn, Label: ""}
+	if err := netlink.AddrAdd(br, addr); err != nil && err != syscall.EEXIST {
+		return fmt.Errorf("could not add IP address to %q: %v", br.Attrs().Name, err)
 	}
 
-	// The namespace must be the same as what was configured
-	if args.Netns != contMap.Sandbox {
-		return fmt.Errorf("Sandbox in prevResult %s doesn't match configured netns: %s",
-			contMap.Sandbox, args.Netns)
-	}
-
-	// Check interface against values found in the container
-	if err := netns.Do(func(_ ns.NetNS) error {
-		contCNI, errLink = validateCniContainerInterface(contMap)
-		if errLink != nil {
-			return errLink
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	// Now look for veth that is peer with container interface.
-	// Anything else wasn't created by CNI, skip it
-	for _, intf := range result.Interfaces {
-		// Skip this result if name is the same as cni bridge
-		// It's either the cni bridge we dealt with above, or something with the
-		// same name in a different namespace.  We just skip since it's not ours
-		if brMap.Name == intf.Name {
-			continue
-		}
-
-		// same here for container name
-		if contMap.Name == intf.Name {
-			continue
-		}
-
-		vethCNI, errLink = validateCniVethInterface(intf, brCNI, contCNI)
-		if errLink != nil {
-			return errLink
-		}
-
-		if vethCNI.found {
-			// veth with container interface as peer and bridge as master found
-			break
-		}
-	}
-
-	if !brCNI.found {
-		return fmt.Errorf("CNI created bridge %s in host namespace was not found", n.BrName)
-	}
-	if !contCNI.found {
-		return fmt.Errorf("CNI created interface in container %s not found", args.IfName)
-	}
-	if !vethCNI.found {
-		return fmt.Errorf("CNI veth created for bridge %s was not found", n.BrName)
-	}
-
-	// Check prevResults for ips, routes and dns against values found in the container
-	if err := netns.Do(func(_ ns.NetNS) error {
-		err = ip.ValidateExpectedInterfaceIPs(args.IfName, result.IPs)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}); err != nil {
-		return err
+	// Set the bridge's MAC to itself. Otherwise, the bridge will take the
+	// lowest-numbered mac on the bridge, and will change as ifs churn
+	if err := netlink.LinkSetHardwareAddr(br, br.Attrs().HardwareAddr); err != nil {
+		return fmt.Errorf("could not set bridge's mac: %v", err)
 	}
 
 	return nil
 }
 
-func main() {
-	//Register the patu plugin, once eBPF programs are loaded.
+func deleteAddr(br netlink.Link, ipn *net.IPNet) error {
+	addr := &netlink.Addr{IPNet: ipn, Label: ""}
+
+	if err := netlink.AddrDel(br, addr); err != nil {
+		return fmt.Errorf("could not remove IP address from %q: %v", br.Attrs().Name, err)
+	}
+
+	return nil
+}
+
+ func bridgeByName(name string) (*netlink.Bridge, error) {
+	 l, err := netlink.LinkByName(name)
+	 if err != nil {
+		 return nil, fmt.Errorf("could not lookup %q: %v", name, err)
+	 }
+	 br, ok := l.(*netlink.Bridge)
+	 if !ok {
+		 return nil, fmt.Errorf("%q already exists but is not a bridge", name)
+	 }
+	 return br, nil
+ }
+ 
+func ensureBridge(brName string, mtu int) (*netlink.Bridge, error) {
+	br := &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: brName,
+			MTU:  mtu,
+			// Let kernel use default txqueuelen; leaving it unset
+			// means 0, and a zero-length TX queue messes up FIFO
+			// traffic shapers which use TX queue length as the
+			// default packet limit
+			TxQLen: -1,
+		},
+	}
+
+	err := netlink.LinkAdd(br)
+	if err != nil && err != syscall.EEXIST {
+		return nil, fmt.Errorf("could not add %q: %v", brName, err)
+	}
+
+	// Re-fetch link to read all attributes and if it already existed,
+	// ensure it's really a bridge with similar configuration
+	br, err = bridgeByName(brName)
+	if err != nil {
+		return nil, err
+	}
+
+	// we want to own the routes for this interface
+	_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", brName), "0")
+
+	if err := netlink.LinkSetUp(br); err != nil {
+		return nil, err
+	}
+
+	return br, nil
+}
+
+func setupVeth(netns ns.NetNS, br *netlink.Bridge, ifName string, mtu int, hairpinMode bool) (*current.Interface, *current.Interface, error) {
+	 contIface := &current.Interface{}
+	 hostIface := &current.Interface{}
+ 
+	 err := netns.Do(func(hostNS ns.NetNS) error {
+		 // create the veth pair in the container and move host end into host netns
+		 hostVeth, containerVeth, err := ip.SetupVeth(ifName, mtu, "", hostNS)
+		 if err != nil {
+			 return err
+		 }
+		 contIface.Name = containerVeth.Name
+		 contIface.Mac = containerVeth.HardwareAddr.String()
+		 contIface.Sandbox = netns.Path()
+		 hostIface.Name = hostVeth.Name
+		 return nil
+	 })
+	 if err != nil {
+		 return nil, nil, err
+	 }
+ 
+	 // need to lookup hostVeth again as its index has changed during ns move
+	 hostVeth, err := netlink.LinkByName(hostIface.Name)
+	 if err != nil {
+		 return nil, nil, fmt.Errorf("failed to lookup %q: %v", hostIface.Name, err)
+	 }
+	 hostIface.Mac = hostVeth.Attrs().HardwareAddr.String()
+ 
+	 // connect host veth end to the bridge
+	 if err := netlink.LinkSetMaster(hostVeth, br); err != nil {
+		 return nil, nil, fmt.Errorf("failed to connect %q to bridge %v: %v", hostVeth.Attrs().Name, br.Attrs().Name, err)
+	 }
+ 
+	// set hairpin mode
+	if err = netlink.LinkSetHairpin(hostVeth, hairpinMode); err != nil {
+		return nil, nil, fmt.Errorf("failed to setup hairpin mode for %v: %v", hostVeth.Attrs().Name, err)
+	}
+
+	 return hostIface, contIface, nil
+ }
+ 
+func calcGatewayIP(ipn *net.IPNet) net.IP {
+	nid := ipn.IP.Mask(ipn.Mask)
+	return ip.NextIP(nid)
+}
+ 
+func setupBridge(n *NetConf) (*netlink.Bridge, *current.Interface, error) {
+	// create bridge if necessary
+	br, err := ensureBridge(n.BrName, n.MTU)
+	 if err != nil {
+		return nil, nil, fmt.Errorf("failed to create bridge %q: %v", n.BrName, err)
+	 }
+ 
+	 return br, &current.Interface{
+		 Name: br.Attrs().Name,
+		 Mac:  br.Attrs().HardwareAddr.String(),
+	 }, nil
+ }
+ 
+func enableIPForward(family int) error {
+	if family == netlink.FAMILY_V4 {
+		return ip.EnableIP4Forward()
+	}
+	return ip.EnableIP6Forward()
+}
+
+ func cmdAdd(args *skel.CmdArgs) error {
+	 var success bool = false
+ 
+	 n, cniVersion, err := loadNetConf(args.StdinData, args.Args)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 isLayer3 := n.IPAM.Type != ""
+ 
+	br, brInterface, err := setupBridge(n)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 netns, err := ns.GetNS(args.Netns)
+	 if err != nil {
+		 return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
+	 }
+	 defer netns.Close()
+ 
+	hostInterface, containerInterface, err := setupVeth(netns, br, args.IfName, n.MTU, n.HairpinMode)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 // Assume L2 interface only
+	 result := &current.Result{
+		 CNIVersion: current.ImplementedSpecVersion,
+		 Interfaces: []*current.Interface{
+			 brInterface,
+			 hostInterface,
+			 containerInterface,
+		 },
+	 }
+ 
+	 if isLayer3 {
+		 // run the IPAM plugin and get back the config to apply
+		 r, err := ipam.ExecAdd(n.IPAM.Type, args.StdinData)
+		 if err != nil {
+			 return err
+		 }
+ 
+		 // release IP in case of failure
+		 defer func() {
+			 if !success {
+				if err := ipam.ExecDel(n.IPAM.Type, args.StdinData); err != nil {
+					fmt.Fprintf(os.Stderr, "%v", err)
+				}
+			 }
+		 }()
+ 
+		 // Convert whatever the IPAM result was into the current Result type
+		 ipamResult, err := current.NewResultFromResult(r)
+		 if err != nil {
+			 return err
+		 }
+ 
+		 result.IPs = ipamResult.IPs
+		 result.Routes = ipamResult.Routes
+		 result.DNS = ipamResult.DNS
+ 
+		 if len(result.IPs) == 0 {
+			 return errors.New("IPAM plugin returned missing IP config")
+		 }
+ 
+		// Gather gateway information for each IP family
+		gwsV4, gwsV6, err := calcGateways(result, n)
+		if err != nil {
+			return err
+		}
+
+		 // Configure the container hardware address and IP address(es)
+		 if err := netns.Do(func(_ ns.NetNS) error {
+			_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv6/conf/%s/accept_dad", args.IfName), "0")
+			_, _ = sysctl.Sysctl(fmt.Sprintf("net/ipv4/conf/%s/arp_notify", args.IfName), "1")
+ 
+			 // Add the IP to the interface
+			 if err := ipam.ConfigureIface(args.IfName, result); err != nil {
+				 return err
+			 }
+			 return nil
+		 }); err != nil {
+			 return err
+		 }
+ 
+		 // check bridge port state
+		 retries := []int{0, 50, 500, 1000, 1000}
+		 for idx, sleep := range retries {
+			 time.Sleep(time.Duration(sleep) * time.Millisecond)
+ 
+			 hostVeth, err := netlink.LinkByName(hostInterface.Name)
+			 if err != nil {
+				 return err
+			 }
+			 if hostVeth.Attrs().OperState == netlink.OperUp {
+				 break
+			 }
+ 
+			 if idx == len(retries)-1 {
+				 return fmt.Errorf("bridge port in error state: %s", hostVeth.Attrs().OperState)
+			 }
+		 }
+
+		if n.IsGW {
+			var firstV4Addr net.IP
+			// Set the IP address(es) on the bridge and enable forwarding
+			for _, gws := range []*gwInfo{gwsV4, gwsV6} {
+				for _, gw := range gws.gws {
+					if gw.IP.To4() != nil && firstV4Addr == nil {
+						firstV4Addr = gw.IP
+					}
+					err = ensureAddr(br, gws.family, &gw, n.ForceAddress)
+					if err != nil {
+						return fmt.Errorf("failed to set bridge addr: %v", err)
+					}
+				}
+
+				if gws.gws != nil {
+					if err = enableIPForward(gws.family); err != nil {
+						return fmt.Errorf("failed to enable forwarding: %v", err)
+					}
+				}
+			}
+		}
+
+		if n.IPMasq {
+			chain := utils.FormatChainName(n.Name, args.ContainerID)
+			comment := utils.FormatComment(n.Name, args.ContainerID)
+			for _, ipc := range result.IPs {
+				if err = ip.SetupIPMasq(&ipc.Address, chain, comment); err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		 if err := netns.Do(func(_ ns.NetNS) error {
+			 link, err := netlink.LinkByName(args.IfName)
+			 if err != nil {
+				 return fmt.Errorf("failed to retrieve link: %v", err)
+			 }
+			 // If layer 2 we still need to set the container veth to up
+			 if err = netlink.LinkSetUp(link); err != nil {
+				 return fmt.Errorf("failed to set %q up: %v", args.IfName, err)
+			 }
+			 return nil
+		 }); err != nil {
+			 return err
+		 }
+	 }
+ 
+	 // Refetch the bridge since its MAC address may change when the first
+	 // veth is added or after its IP address is set
+	 br, err = bridgeByName(n.BrName)
+	 if err != nil {
+		 return err
+	 }
+	 brInterface.Mac = br.Attrs().HardwareAddr.String()
+ 
+	// Use incoming DNS settings if provided, otherwise use the
+	// settings that were already configured by the IPAM plugin
+	if dnsConfSet(n.DNS) {
+		result.DNS = n.DNS
+	}
+
+	 success = true
+ 
+	 return types.PrintResult(result, cniVersion)
+ }
+ 
+func dnsConfSet(dnsConf types.DNS) bool {
+	return dnsConf.Nameservers != nil ||
+		dnsConf.Search != nil ||
+		dnsConf.Options != nil ||
+		dnsConf.Domain != ""
+}
+
+ func cmdDel(args *skel.CmdArgs) error {
+	 n, _, err := loadNetConf(args.StdinData, args.Args)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 isLayer3 := n.IPAM.Type != ""
+ 
+	 ipamDel := func() error {
+		 if isLayer3 {
+			 if err := ipam.ExecDel(n.IPAM.Type, args.StdinData); err != nil {
+				 return err
+			 }
+		 }
+		 return nil
+	 }
+ 
+	 if args.Netns == "" {
+		 return ipamDel()
+	 }
+ 
+	 // There is a netns so try to clean up. Delete can be called multiple times
+	 // so don't return an error if the device is already removed.
+	 // If the device isn't there then don't try to clean up IP masq either.
+	var ipnets []*net.IPNet
+	 err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+		 var err error
+		ipnets, err = ip.DelLinkByNameAddr(args.IfName)
+		 if err != nil && err == ip.ErrLinkNotFound {
+			 return nil
+		 }
+		 return err
+	 })
+ 
+	 if err != nil {
+		 //  if NetNs is passed down by the Cloud Orchestration Engine, or if it called multiple times
+		 // so don't return an error if the device is already removed.
+		 // https://github.com/kubernetes/kubernetes/issues/43014#issuecomment-287164444
+		 _, ok := err.(ns.NSPathNotExistErr)
+		 if ok {
+			 return ipamDel()
+		 }
+		 return err
+	 }
+ 
+	 // call ipam.ExecDel after clean up device in netns
+	 if err := ipamDel(); err != nil {
+		 return err
+	 }
+ 
+	if isLayer3 && n.IPMasq {
+		chain := utils.FormatChainName(n.Name, args.ContainerID)
+		comment := utils.FormatComment(n.Name, args.ContainerID)
+		for _, ipn := range ipnets {
+			if err := ip.TeardownIPMasq(ipn, chain, comment); err != nil {
+				return err
+			}
+		}
+	}
+
+	 return err
+ }
+ 
+ type cniBridgeIf struct {
+	 Name        string
+	 ifIndex     int
+	 peerIndex   int
+	 masterIndex int
+	 found       bool
+ }
+ 
+ func validateInterface(intf current.Interface, expectInSb bool) (cniBridgeIf, netlink.Link, error) {
+ 
+	 ifFound := cniBridgeIf{found: false}
+	 if intf.Name == "" {
+		 return ifFound, nil, fmt.Errorf("Interface name missing ")
+	 }
+ 
+	 link, err := netlink.LinkByName(intf.Name)
+	 if err != nil {
+		 return ifFound, nil, fmt.Errorf("Interface name %s not found", intf.Name)
+	 }
+ 
+	 if expectInSb {
+		 if intf.Sandbox == "" {
+			 return ifFound, nil, fmt.Errorf("Interface %s is expected to be in a sandbox", intf.Name)
+		 }
+	 } else {
+		 if intf.Sandbox != "" {
+			 return ifFound, nil, fmt.Errorf("Interface %s should not be in sandbox", intf.Name)
+		 }
+	 }
+ 
+	 return ifFound, link, err
+ }
+ 
+ func validateCniBrInterface(intf current.Interface, n *NetConf) (cniBridgeIf, error) {
+ 
+	 brFound, link, err := validateInterface(intf, false)
+	 if err != nil {
+		 return brFound, err
+	 }
+ 
+	 _, isBridge := link.(*netlink.Bridge)
+	 if !isBridge {
+		 return brFound, fmt.Errorf("Interface %s does not have link type of bridge", intf.Name)
+	 }
+ 
+	 if intf.Mac != "" {
+		 if intf.Mac != link.Attrs().HardwareAddr.String() {
+			 return brFound, fmt.Errorf("Bridge interface %s Mac doesn't match: %s", intf.Name, intf.Mac)
+		 }
+	 }
+ 
+	 brFound.found = true
+	 brFound.Name = link.Attrs().Name
+	 brFound.ifIndex = link.Attrs().Index
+	 brFound.masterIndex = link.Attrs().MasterIndex
+ 
+	 return brFound, nil
+ }
+ 
+ func validateCniVethInterface(intf *current.Interface, brIf cniBridgeIf, contIf cniBridgeIf) (cniBridgeIf, error) {
+ 
+	 vethFound, link, err := validateInterface(*intf, false)
+	 if err != nil {
+		 return vethFound, err
+	 }
+ 
+	 _, isVeth := link.(*netlink.Veth)
+	 if !isVeth {
+		 // just skip it, it's not what CNI created
+		 return vethFound, nil
+	 }
+ 
+	 _, vethFound.peerIndex, err = ip.GetVethPeerIfindex(link.Attrs().Name)
+	 if err != nil {
+		 return vethFound, fmt.Errorf("Unable to obtain veth peer index for veth %s", link.Attrs().Name)
+	 }
+	 vethFound.ifIndex = link.Attrs().Index
+	 vethFound.masterIndex = link.Attrs().MasterIndex
+ 
+	 if vethFound.ifIndex != contIf.peerIndex {
+		 return vethFound, nil
+	 }
+ 
+	 if contIf.ifIndex != vethFound.peerIndex {
+		 return vethFound, nil
+	 }
+ 
+	 if vethFound.masterIndex != brIf.ifIndex {
+		 return vethFound, nil
+	 }
+ 
+	 if intf.Mac != "" {
+		 if intf.Mac != link.Attrs().HardwareAddr.String() {
+			 return vethFound, fmt.Errorf("Interface %s Mac doesn't match: %s not found", intf.Name, intf.Mac)
+		 }
+	 }
+ 
+	 vethFound.found = true
+	 vethFound.Name = link.Attrs().Name
+ 
+	 return vethFound, nil
+ }
+ 
+ func validateCniContainerInterface(intf current.Interface) (cniBridgeIf, error) {
+ 
+	 vethFound, link, err := validateInterface(intf, true)
+	 if err != nil {
+		 return vethFound, err
+	 }
+ 
+	 _, isVeth := link.(*netlink.Veth)
+	 if !isVeth {
+		 return vethFound, fmt.Errorf("Error: Container interface %s not of type veth", link.Attrs().Name)
+	 }
+	 _, vethFound.peerIndex, err = ip.GetVethPeerIfindex(link.Attrs().Name)
+	 if err != nil {
+		 return vethFound, fmt.Errorf("Unable to obtain veth peer index for veth %s", link.Attrs().Name)
+	 }
+	 vethFound.ifIndex = link.Attrs().Index
+ 
+	 if intf.Mac != "" {
+		 if intf.Mac != link.Attrs().HardwareAddr.String() {
+			 return vethFound, fmt.Errorf("Interface %s Mac %s doesn't match container Mac: %s", intf.Name, intf.Mac, link.Attrs().HardwareAddr)
+		 }
+	 }
+ 
+	 vethFound.found = true
+	 vethFound.Name = link.Attrs().Name
+ 
+	 return vethFound, nil
+ }
+ 
+ func cmdCheck(args *skel.CmdArgs) error {
+
+	 n, _, err := loadNetConf(args.StdinData, args.Args)
+	 if err != nil {
+		 return err
+	 }
+	 netns, err := ns.GetNS(args.Netns)
+	 if err != nil {
+		 return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
+	 }
+	 defer netns.Close()
+ 
+	 // run the IPAM plugin and get back the config to apply
+	 err = ipam.ExecCheck(n.IPAM.Type, args.StdinData)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 // Parse previous result.
+	 if n.NetConf.RawPrevResult == nil {
+		 return fmt.Errorf("Required prevResult missing")
+	 }
+ 
+	 if err := version.ParsePrevResult(&n.NetConf); err != nil {
+		 return err
+	 }
+ 
+	 result, err := current.NewResultFromResult(n.PrevResult)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 var errLink error
+	 var contCNI, vethCNI cniBridgeIf
+	 var brMap, contMap current.Interface
+ 
+	// Find interfaces for names we know, CNI Bridge and container
+	 for _, intf := range result.Interfaces {
+		 if n.BrName == intf.Name {
+			 brMap = *intf
+			 continue
+		 } else if args.IfName == intf.Name {
+			 if args.Netns == intf.Sandbox {
+				 contMap = *intf
+				 continue
+			 }
+		 }
+	 }
+ 
+	 brCNI, err := validateCniBrInterface(brMap, n)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 // The namespace must be the same as what was configured
+	 if args.Netns != contMap.Sandbox {
+		 return fmt.Errorf("Sandbox in prevResult %s doesn't match configured netns: %s",
+			 contMap.Sandbox, args.Netns)
+	 }
+ 
+	 // Check interface against values found in the container
+	 if err := netns.Do(func(_ ns.NetNS) error {
+		 contCNI, errLink = validateCniContainerInterface(contMap)
+		 if errLink != nil {
+			 return errLink
+		 }
+		 return nil
+	 }); err != nil {
+		 return err
+	 }
+ 
+	 // Now look for veth that is peer with container interface.
+	 // Anything else wasn't created by CNI, skip it
+	 for _, intf := range result.Interfaces {
+		 // Skip this result if name is the same as cni bridge
+		 // It's either the cni bridge we dealt with above, or something with the
+		 // same name in a different namespace.  We just skip since it's not ours
+		 if brMap.Name == intf.Name {
+			 continue
+		 }
+ 
+		 // same here for container name
+		 if contMap.Name == intf.Name {
+			 continue
+		 }
+ 
+		 vethCNI, errLink = validateCniVethInterface(intf, brCNI, contCNI)
+		 if errLink != nil {
+			 return errLink
+		 }
+ 
+		 if vethCNI.found {
+			 // veth with container interface as peer and bridge as master found
+			 break
+		 }
+	 }
+ 
+	 if !brCNI.found {
+		 return fmt.Errorf("CNI created bridge %s in host namespace was not found", n.BrName)
+	 }
+	 if !contCNI.found {
+		 return fmt.Errorf("CNI created interface in container %s not found", args.IfName)
+	 }
+	 if !vethCNI.found {
+		 return fmt.Errorf("CNI veth created for bridge %s was not found", n.BrName)
+	 }
+ 
+	 // Check prevResults for ips, routes and dns against values found in the container
+	 if err := netns.Do(func(_ ns.NetNS) error {
+		 err = ip.ValidateExpectedInterfaceIPs(args.IfName, result.IPs)
+		 if err != nil {
+			 return err
+		 }
+ 
+		err = ip.ValidateExpectedRoute(result.Routes)
+		if err != nil {
+			return err
+		}
+		 return nil
+	 }); err != nil {
+		 return err
+	 }
+ 
+	 return nil
+ }
+
+ func main() {
 	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("patu"))
 }

--- a/deploy/patu.yaml
+++ b/deploy/patu.yaml
@@ -47,6 +47,8 @@ data:
       "cniVersion": "0.3.1",
       "name": "patu-network",
       "type": "patu",
+      "bridge": "patux",
+      "isGateway": true,
       "ipam": {
         "type": "host-local",
         "ranges": [

--- a/scripts/post-cni.sh
+++ b/scripts/post-cni.sh
@@ -16,5 +16,7 @@
 
 #!/bin/sh
 
+bridge=`awk '/"bridge"/' /etc/cni/net.d/10-patu.conf | cut -d '"' -f4`
 rm /opt/cni/bin/patu
 rm /etc/cni/net.d/10-patu.conf
+ip link delete $bridge


### PR DESCRIPTION
to enable first packet forwarding.

Also it uses it's own bridge to enable
the forwarding, so that cni0 can be used
as a backoff bridge in case patu cni is removed.

Signed-off-by: Anil Vishnoi <avishnoi@redhat.com>