### PR TITLE
Legacy BPF maps coded into BTF defined maps

### DIFF
--- a/bpf/include/helpers/helpers.h
+++ b/bpf/include/helpers/helpers.h
@@ -16,6 +16,7 @@ limitations under the License.
 
 #pragma once
 
+#include "maps.h"
 #include <linux/bpf.h>
 #include <linux/swab.h>
 
@@ -56,16 +57,6 @@ struct socket_key {
   __u32 dst_ip;
   __u16 src_port;
   __u16 dst_port;
-};
-
-struct bpf_map {
-  __u32 id;
-  __u32 type;
-  __u32 key_size;
-  __u32 value_size;
-  __u32 max_elem;
-  __u32 flags;
-  __u32 pinning;
 };
 
 static __u64 BPF_FUNC(get_current_pid_tgid);

--- a/bpf/include/helpers/maps.h
+++ b/bpf/include/helpers/maps.h
@@ -15,11 +15,19 @@
  */
 #pragma once
 
-#include <linux/bpf.h>
+#define __uint(name, val) int(*name)[val]
+#define __type(name, val) typeof(val) *name
 
-struct bpf_map __section("maps") sockops_redir_map = {
-    .type = BPF_MAP_TYPE_SOCKHASH,
-    .key_size = sizeof(struct socket_key),
-    .value_size = sizeof(__u32),
-    .max_elem = 65535,
-};
+#define SEC(name)                                                              \
+  _Pragma("GCC diagnostic push")                                               \
+      _Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")               \
+          __attribute__((section(name), used)) _Pragma("GCC diagnostic pop")
+
+#define MAX_ENTRIES 65535
+
+struct bpf_map {
+  __uint(type, BPF_MAP_TYPE_SOCKHASH);
+  __uint(max_entries, MAX_ENTRIES);
+  __type(key, struct socket_key);
+  __type(value, __u32);
+} sockops_redir_map SEC(".maps");


### PR DESCRIPTION
As proposed in issue https://github.com/redhat-et/patu/issues/50, sockops_redir_map coded as BTF-defined map.

Testing approach:
patu.yml applied and tested before change - all ebpf programs loaded successfully, map created with sockhash type; no elements
patu.yml applied and tested post change - results replicated as before. Logs verified confirming creation of map.

Logs:
`map 'sockops_redir_map': created successfully, fd=4	
2022-07-20T23:59:25.576831938+00:00 stderr F libbpf: map '.rodata.str1.1': created successfully, fd=5`

Resolves: https://github.com/redhat-et/patu/issues/50

Earlier raised as PR #69.
Updates:
1. Implementation of review comments from #69
2. Bug fix - Struct in helpers.h BPF method and one in maps.h was being considered as separate declarations of the map due to incorrect map name.