### PR TITLE
Job to build and push KPNG image

### DIFF
--- a/.github/workflows/build-push-kpng-image.yml
+++ b/.github/workflows/build-push-kpng-image.yml
@@ -1,10 +1,8 @@
 name: Build and Push KPNG Image
-#on: workflow_dispatch
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: workflow_dispatch
+#on:
+#  pull_request:
+#    branches: [ "main" ]
     
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Job build and push KPNG image in the patu packages so that it can be used for easier deployment of the patu CNI.