### PR TITLE
Move hash-bang in the installer to top of file

### DIFF
--- a/scripts/installer/patu-installer
+++ b/scripts/installer/patu-installer
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # Copyright © 2022 Authors of Patu
 #
@@ -13,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/sh
 
 # This script allows for 3 kinds of options- each available with two commands:
 # Command can be apply | delete


### PR DESCRIPTION
- Moving the hash bang to the top of the file so it is read to
  avoid exec format errors when calling the file from a sub shell

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>