### PR TITLE
Adjust the installer to be run from the root of the repo

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.gitignore'
 
 env:
   GO_VERSION: "1.18.4"

--- a/hack/kubernetes/README.md
+++ b/hack/kubernetes/README.md
@@ -14,52 +14,56 @@ Install kubernetes without kube-proxy  | Remove kube-proxy
     `kubeadm init  --upload-certs --pod-network-cidr=10.200.0.0/16 --v=6 --skip-phases=addon/kube-proxy`  
     Or can disable kube-proxy, using kubectl to delete the kube-proxy daemonset from kube-system namespace  
     `kubectl delete daemonsets -n kube-system kube-proxy`  
-2. Clone the following repository on the kubernetes control plane node  
-   Link: https://github.com/redhat-et/patu.git  
+2. Clone the following repository on the kubernetes control plane node
+   Link: [redhat-et/patu](https://github.com/redhat-et/patu.git)
+
+```shell
+git clone https://github.com/redhat-et/patu.git
+```
 
 
 #### Install PATU CNI  
 1. Deploy Patu  
-    Execute this command: `<path-to-patu-repo>/patu/scripts/installer/patu-installer apply cni`  
+    Execute this command from the patu directory: `./scripts/installer/patu-installer apply cni`  
     Ensure the script doesn't result in any errors.   
-2. Ensure status - All pods should be in running state. Coredns pods should have IP from patu CIDR as mentioned in <path-to-patu-repo>/patu/deploy/patu.yaml, and should be running but not ready
+2. Ensure status - All pods should be in running state. Coredns pods should have IP from patu CIDR as mentioned in `./deploy/patu.yaml`, and should be running but not ready
 
 
 
 #### Install KPNG  
 1. Deploy kpng  
-    Execute this command: `<path-to-patu-repo>/patu/scripts/installer/patu-installer apply kpng`   
+    Execute this command from the patu directory: `./scripts/installer/patu-installer apply kpng`   
     Ensure the script doesn't result in any errors.  
 2. Ensure status - All pods should be in running and ready state. Coredns pods should have IP from patu CIDR, KPNG pod should have 3 containers running and ready 
 
 
 #### Remove KPNG  
-1. Execute this command: `<path-to-patu-repo>/patu/scripts/installer/patu-installer delete kpng`  
+1. Execute this command from the patu directory: `./scripts/installer/patu-installer delete kpng`  
    Ensure the script doesn't result in any errors.
 
 
 #### Remove PATU CNI
-1. Execute this command: `<path-to-patu-repo>/patu/scripts/installer/patu-installer delete cni`    
+1. Execute this command from the patu directory: `./scripts/installer/patu-installer delete cni`    
    Ensure the script doesn't result in any errors.  
 
 
 #### INSTALL-ALL:  
 1. Deploy patu and kpng  
-    Execute this command: `<path-to-patu-repo>/patu/scripts/installer/patu-installer apply all`   
+    Execute this command from the patu directory: `./scripts/installer/patu-installer apply all`   
     Ensure the script doesn't result in any errors.  
 2. Ensure status - All pods should be in running and ready state. Coredns pods should have IP from patu CIDR, KPNG pod should have 3 containers running and ready  
 
 
 
 #### REMOVE-ALL:  
-1. Execute this command: `<path-to-patu-repo>/patu/scripts/installer/patu-installer delete all`    
+1. Execute this command from the patu directory: `./scripts/installer/patu-installer delete all`    
    Ensure the script doesn't result in any errors.  
 
 
 ### Manual Instructions:
 
 #### Install Patu CNI   
-1. `kubectl apply -f <path-to-patu-repo>/patu/deploy/patu.yaml`  
+1. Deploy Patu CNI from the patu directory `kubectl apply -f ./deploy/patu.yaml`  
 2. Ensure status - All pods should be in running state. Coredns pods should have IP from patu CIDR as mentioned in patu.yaml, and should be running but not ready
 
 
@@ -75,18 +79,18 @@ Install kubernetes without kube-proxy  | Remove kube-proxy
     `kubectl label node $local_node kube-proxy=kpng`  
 4. Create configmap:  
     `kubectl create configmap kpng --namespace kube-system --from-file /etc/kubernetes/admin.conf`  
-5. Deploy kpng:
-    `kubectl apply -f <path-to-patu-repo>/patu/hack.kubernetes/kpngebpf.yaml`  
+5. Deploy kpng from the patu directory:
+    `kubectl apply -f ./hack.kubernetes/kpngebpf.yaml`  
 6. Ensure status - All pods should be in running and ready state. Coredns pods should have IP from patu CIDR, KPNG pod should have 3 containers running and ready  
 
 
 #### Remove KPNG  
 1. Remove KPNG Daemon set, service account, cluster role+ binding:  
-    `kubectl delete -f <path-to-patu-repo>/patu/hack.kubernetes/kpngebpf.yaml`  
+    `kubectl delete -f ./patu/hack.kubernetes/kpngebpf.yaml`  
 2. Remove configmap:  
     `kubectl delete cm kpng -n kube-system`
 3. Extract node name:  
-    ```
+    ```shell
     (ip addr | awk '/inet/{print $2}' | awk -F/ '{print $1}') > /tmp/internal_ip.txt  
     local_node=$(kubectl get node -o wide | grep -f /tmp/internal_ip.txt | awk '{print $1}')
     ```
@@ -96,13 +100,16 @@ Install kubernetes without kube-proxy  | Remove kube-proxy
 
 #### Remove PATU
 1. Remove PATU Daemon set, service account, cluster role+ binding:  
-    `kubectl delete -f <path-to-patu-repo>/patu/deploy/patu.yaml` 
+    `kubectl delete -f ./patu/deploy/patu.yaml` 
     
 
 ## Testing setup:
-1. `kubectl create -f https://k8s.io/examples/application/deployment.yaml`
-2. `kubectl expose deployment nginx-deployment --type=ClusterIP`
-3. `kubectl run tmp-shell --rm -i --tty --image nicolaka/netshoot`
+
+```shell
+kubectl create -f https://k8s.io/examples/application/deployment.yaml
+kubectl expose deployment nginx-deployment --type=ClusterIP
+kubectl run tmp-shell --rm -i --tty --image nicolaka/netshoot
+```
 
 Expected: Curl to the exposed ip of the nginx-deployment service (obtained using `kubectl get svc -A -o wide`) should work from the tmp-shell.
 Coredns pods should be in ready state.

--- a/scripts/installer/patu-installer
+++ b/scripts/installer/patu-installer
@@ -35,8 +35,8 @@
 # ./patu-installer apply all
 
 KUBECONFIG=${KUBECONFIG:="/etc/kubernetes/admin.conf"}
-PATU_CONFIG=${PATU_CONFIG:="patu/deploy/patu.yaml"}
-KPNG_CONFIG=${KPNG_CONFIG:="patu/hack/kubernetes/kpngebpf.yaml"}
+PATU_CONFIG=${PATU_CONFIG:="deploy/patu.yaml"}
+KPNG_CONFIG=${KPNG_CONFIG:="hack/kubernetes/kpngebpf.yaml"}
 
 arg=$1
 opt=$2
@@ -59,7 +59,7 @@ if ! file_exists ${PATU_CONFIG}; then
     exit 1
 fi
 if ! file_exists ${KPNG_CONFIG}; then
-    echo -e "\npatu.yaml not found at ${KPNG_CONFIG}. Please set it using 'export KPNG_CONFIG=/path/to/kpngebpf.yaml'\n"
+    echo -e "\nkpngebpf.yaml not found at ${KPNG_CONFIG}. Please set it using 'export KPNG_CONFIG=/path/to/kpngebpf.yaml'\n"
     exit 1
 fi
 

--- a/scripts/local-e2e.sh
+++ b/scripts/local-e2e.sh
@@ -485,10 +485,14 @@ nodes:
             authorization-mode: "AlwaysAllow"
 EOF
 
-    # Copy installer script and deployment files for installer
-    mkdir -p patu/deploy/
-    cp ../deploy/* patu/deploy/
-    cp ../scripts/installer/patu-installer ${bin_dir}
+    # Copy installer script to the bin dir to add it to the shells path
+    cp installer/patu-installer ${bin_dir}
+
+    # Copy installer script and deployment files for installer in e2e
+    mkdir -p ../test/e2e/deploy
+    mkdir -p ../test/e2e/hack/kubernetes/
+    cp ../deploy/* ../test/e2e/deploy
+    cp ../hack/kubernetes/* ../test/e2e/hack/kubernetes/
 
     # Install Kubeproxy backend matrix
     if [ "${backend}" == "kubeproxy" ]; then
@@ -505,8 +509,10 @@ EOF
             --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--v='"${kind_cluster_log_level}"'" }]'
 
         # Install Patu using the installer
+        pushd ../
         KUBECONFIG=${HOME}/.kube/config patu-installer apply cni
         if_error_exit "Failed to install Patu"
+        popd
     fi
 
     # Install KPNG backend matrix
@@ -522,8 +528,10 @@ EOF
         if_error_exit "cannot create kind cluster ${cluster_name}"
 
         # Install Patu using the installer
+        pushd ../
         KUBECONFIG=${HOME}/.kube/config patu-installer apply all
         if_error_exit "Failed to install Patu"
+        popd
     fi
 
     kind get kubeconfig --internal --name "${cluster_name}" >"${artifacts_directory}/kubeconfig.conf"

--- a/test/scripts/setup-kind.sh
+++ b/test/scripts/setup-kind.sh
@@ -497,10 +497,10 @@ EOF
     # Copy installer script and deployment files for installer in e2e
     # This also tests the default filepath installation in e2e rather
     # than via ENVs in the kind cluster setup in CI
-    mkdir -p $HOME/work/patu/patu/test/e2e/patu/deploy
-    mkdir -p $HOME/work/patu/patu/test/e2e/patu/hack/kubernetes/
-    cp $HOME/work/patu/patu/deploy/* $HOME/work/patu/patu/test/e2e/patu/deploy/
-    cp $HOME/work/patu/patu/hack/kubernetes/* $HOME/work/patu/patu/test/e2e/patu/hack/kubernetes/
+    mkdir -p $HOME/work/patu/patu/test/e2e/deploy
+    mkdir -p $HOME/work/patu/patu/test/e2e/hack/kubernetes/
+    cp $HOME/work/patu/patu/deploy/* $HOME/work/patu/patu/test/e2e/deploy/
+    cp $HOME/work/patu/patu/hack/kubernetes/* $HOME/work/patu/patu/test/e2e/hack/kubernetes/
 
     # Install Kubeproxy backend matrix
     if [ "${backend}" == "kubeproxy" ]; then


### PR DESCRIPTION
- Changed the installer to be run from the patu repo root.
- Updated install readme.
- Updated CI kind installer to copy e2e files that validate
  that install option to use the root dir.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>