### PR TITLE
Added periodic workflow perf testing issue trigger

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -7,6 +7,14 @@ on:
 jobs:
   deploy-perf-scale:
     name: deploy-perf-scale
+    if: >-
+      (
+        github.event_name == 'schedule'
+      ) || (
+        github.event.issue.pull_request &&
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER') &&
+        contains(github.event.comment.body, '/perf-test')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
- This enables repo owners and members to trigger the periodic workflow performance tests from issue comments. This trigger is `/perf-tests`.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>